### PR TITLE
Handle errors from mubsub.

### DIFF
--- a/lib/mongostore.js
+++ b/lib/mongostore.js
@@ -34,14 +34,17 @@ function Mongo(options){
   self._nodeId = options.nodeId || Math.round(Math.random() * Date.now());
   self._subscriptions = {};
 
+  self._error = self._error.bind(this);
+
   // all instances share one connection
   if (!client) {
     client = mubsub(options.url,{safe :true});
+    client.on('error', self._error);
   }
   //self.client = client;
 
-  self._channel =client.channel(options.collectionPrefix + options.streamCollection, options);
-  self._error = self._error.bind(this);
+  self._channel = client.channel(options.collectionPrefix + options.streamCollection, options);
+  self._channel.on('error', self._error);
 
   /*client.connection.db.then(function(err, db) {
    self.emit('connect', err, db);


### PR DESCRIPTION
If mubsub throws an error it should send to this projects error event handler.

We ran into a case where mubsub was throwing an error and would crash our entire service.
